### PR TITLE
Add rosidl_generator_tests to ignore list

### DIFF
--- a/rolling.ignored
+++ b/rolling.ignored
@@ -1,1 +1,2 @@
+rosidl_generator_tests
 rosidl_typesupport_introspection_tests


### PR DESCRIPTION
I just guessed that the format of the ignored file is one package per line :shrug: 